### PR TITLE
Use shell entrypoint so multiple files can be provided

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ runs:
   entrypoint: sh
   args:
   - -c
-  - conftest test -o ${{ inputs.output }} -p ${{ inputs.policy }} --namespace ${{ inputs.namespace }} --combine=${{ inputs.combine }} ${{ inputs.files }} 
+  - conftest test -o "${{ inputs.output }}" -p "${{ inputs.policy }}" --namespace "${{ inputs.namespace }}" --combine="${{ inputs.combine }}" ${{ inputs.files }} 

--- a/action.yml
+++ b/action.yml
@@ -23,4 +23,4 @@ runs:
   entrypoint: sh
   args:
   - -c
-  - test -o ${{ inputs.output }} -p ${{ inputs.policy }} --namespace ${{ inputs.namespace }} ${{ inputs.files }} 
+  - conftest test -o ${{ inputs.output }} -p ${{ inputs.policy }} --namespace ${{ inputs.namespace }} ${{ inputs.files }} 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   namespace:
     description: "The Rego namespace to use for testing"
     default: "main"
+  combine:
+    description: "Whether to combine input files"
+    default: "false"
   output:
     description: "Output format for results"
     default: "stdout"
@@ -23,4 +26,4 @@ runs:
   entrypoint: sh
   args:
   - -c
-  - conftest test -o ${{ inputs.output }} -p ${{ inputs.policy }} --namespace ${{ inputs.namespace }} ${{ inputs.files }} 
+  - conftest test -o ${{ inputs.output }} -p ${{ inputs.policy }} --namespace ${{ inputs.namespace }} --combine=${{ inputs.combine }} ${{ inputs.files }} 

--- a/action.yml
+++ b/action.yml
@@ -20,12 +20,7 @@ inputs:
 runs:
   using: 'docker'
   image: 'docker://instrumenta/conftest:latest'
+  entrypoint: sh
   args:
-  - test
-  - -o
-  - ${{ inputs.output }}
-  - -p
-  - ${{ inputs.policy }}
-  - --namespace
-  - ${{ inputs.namespace }}
-  - ${{ inputs.files }} 
+  - -c
+  - test -o ${{ inputs.output }} -p ${{ inputs.policy }} --namespace ${{ inputs.namespace }} ${{ inputs.files }} 


### PR DESCRIPTION
By executing a shell instead of conftest directly, our input files can be parsed individually rather than as a single string.

Also, this PR adds support for the `--combined` flag, because it is very handy!

Resolves https://github.com/instrumenta/conftest-action/issues/1
