### PR TITLE
Allow for output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,13 @@ inputs:
   output:
     description: "Output format for results"
     default: "stdout"
+outputs:
+  results:
+    description: "The results of the Conftest"
 runs:
   using: 'docker'
   image: 'docker://instrumenta/conftest:latest'
   entrypoint: sh
   args:
   - -c
-  - conftest test -o "${{ inputs.output }}" -p "${{ inputs.policy }}" --namespace "${{ inputs.namespace }}" --combine="${{ inputs.combine }}" ${{ inputs.files }} 
+  - echo ::set-output name=results::$(conftest test -o "${{ inputs.output }}" -p "${{ inputs.policy }}" --namespace "${{ inputs.namespace }}" --combine="${{ inputs.combine }}" ${{ inputs.files }}) 


### PR DESCRIPTION
We are using OPA / Conftest for terraform. We wanted the output so we can put it in Check (https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api).

If there's a better way to do this let me know. We are using my fork currently. 