### PR TITLE
Use proper upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ passed to the action using `with`, as demonstrated with `files` in the above exa
 | files | - | *Required* which files to test |
 | policy | policy | Where to find the policy folder or files |
 | namespace | main | The Rego namespace to use for testing |
-| output | stdout | How to format the output from Conftest (stdout, json or tap) |
+| output | stdout | How to format the output from Conftest (stdout, github, json or tap, check the full list [here](https://www.conftest.dev/options/#-output)) |
 
 
 ## Helm
@@ -58,7 +58,7 @@ passed to the action using `with`, as demonstrated with `chart` in the above exa
 | chart | - | *Required* which chart directory to test |
 | policy | policy | Where to find the policy folder or files |
 | namespace | main | The Rego namespace to use for testing |
-| output | stdout | How to format the output from Conftest (stdout, json or tap) |
+| output | stdout | How to format the output from Conftest (stdout, github, json or tap, check the full list [here](https://www.conftest.dev/options/#-output)) |
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -1,3 +1,4 @@
+---
 name: "Conftest"
 description: "Write tests against structured configuration data using Open Policy Agent"
 author: "Gareth Rushgrove"
@@ -22,7 +23,7 @@ inputs:
     default: "stdout"
 runs:
   using: 'docker'
-  image: 'docker://instrumenta/conftest:latest'
+  image: 'docker://openpolicyagent/conftest:latest'
   entrypoint: sh
   args:
   - -c


### PR DESCRIPTION
As written at https://www.conftest.dev/install/#docker the `instrumenta/conftest` image is now obsolete.

> NOTE: The instrumenta/conftest image is deprecated and will no longer be updated. Please use the openpolicyagent/conftest image.